### PR TITLE
Fixing Firefox bunyan error

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "browserify": "11.0.1",
     "level-js": "2.2.1",
     "reuters-21578-json": "0.0.6",
-    "search-index": "0.6.8"
+    "search-index": "0.6.11"
   },
   "keywords": [
     "search-index",


### PR DESCRIPTION
Now working in Firefox: https://github.com/fergiemcdowall/search-index-replicate-index-to-browser-example/issues/3
